### PR TITLE
fix: close popup when clicking outside on Hyprland

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ pub enum WindowInfo
     MainBar,
     Warning,
     ContextMenu,
+    ContextMenuBackdrop,
     Calendar,
     VolumeOutputMixer,
     VolumeInputMixer

--- a/src/update.rs
+++ b/src/update.rs
@@ -161,7 +161,7 @@ pub fn update(app: &mut AppData, message: Message) -> Task<Message>
             println!("Id: {id}");
 
             app.context_menu_data.context_menu_is_open = false;
-            let window_ids_to_close: Vec<iced::window::Id> = app.ids.iter().filter(|(_, info)| **info == WindowInfo::ContextMenu).map(|(id, _)| *id).collect();
+            let window_ids_to_close: Vec<iced::window::Id> = app.ids.iter().filter(|(_, info)| **info == WindowInfo::ContextMenu || **info == WindowInfo::ContextMenuBackdrop).map(|(id, _)| *id).collect();
             for id in &window_ids_to_close { app.ids.remove(id); }
             let close_tasks = Task::batch(window_ids_to_close.into_iter().map(|id| Task::done(Message::RemoveWindow(id))));
             let activate_task = Task::perform
@@ -208,13 +208,13 @@ pub fn update(app: &mut AppData, message: Message) -> Task<Message>
         {
             let mut tasks: Vec<Task<Message>> = Vec::new();
 
-            let has_context_menu = app.ids.values().any(|v| *v == WindowInfo::ContextMenu);
+            let has_context_menu = app.ids.values().any(|v| *v == WindowInfo::ContextMenu || *v == WindowInfo::ContextMenuBackdrop);
             if has_context_menu
             {
                 app.context_menu_data.context_menu_is_open = false;
                 if !app.context_menu_data.cursor_is_inside_menu
                 {
-                    let ids_to_close: Vec<iced::window::Id> = app.ids.iter().filter(|(_, info)| **info == WindowInfo::ContextMenu).map(|(id, _)| *id).collect();
+                    let ids_to_close: Vec<iced::window::Id> = app.ids.iter().filter(|(_, info)| **info == WindowInfo::ContextMenu || **info == WindowInfo::ContextMenuBackdrop).map(|(id, _)| *id).collect();
                     for id in &ids_to_close { app.ids.remove(id); }
                     tasks.extend(ids_to_close.into_iter().map(|id| Task::done(Message::RemoveWindow(id))));
                 }
@@ -253,7 +253,7 @@ pub fn update(app: &mut AppData, message: Message) -> Task<Message>
         Message::CloseContextMenu =>
         {
             app.context_menu_data.context_menu_is_open = false;
-            let window_ids_to_close: Vec<iced::window::Id> = app.ids.iter().filter(|(_, info)| **info == WindowInfo::ContextMenu).map(|(id, _)| *id).collect();
+            let window_ids_to_close: Vec<iced::window::Id> = app.ids.iter().filter(|(_, info)| **info == WindowInfo::ContextMenu || **info == WindowInfo::ContextMenuBackdrop).map(|(id, _)| *id).collect();
             for id in &window_ids_to_close { app.ids.remove(id); }
             maybe_restart_hide_timer(app);
             return Task::batch(window_ids_to_close.into_iter().map(|id| Task::done(Message::RemoveWindow(id))));
@@ -291,7 +291,7 @@ pub fn update(app: &mut AppData, message: Message) -> Task<Message>
             let mut tasks: Vec<Task<Message>> = Vec::new();
 
             app.context_menu_data.context_menu_is_open = false;
-            let context_ids: Vec<iced::window::Id> = app.ids.iter().filter(|(_, info)| **info == WindowInfo::ContextMenu).map(|(id, _)| *id).collect();
+            let context_ids: Vec<iced::window::Id> = app.ids.iter().filter(|(_, info)| **info == WindowInfo::ContextMenu || **info == WindowInfo::ContextMenuBackdrop).map(|(id, _)| *id).collect();
             for id in &context_ids { app.ids.remove(id); }
             tasks.extend(context_ids.into_iter().map(|id| Task::done(Message::RemoveWindow(id))));
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -37,6 +37,14 @@ pub fn view(app: &AppData, id: iced::window::Id) -> Element<'_, Message>
 {
     match id_info(app, id) 
     {
+        Some(WindowInfo::ContextMenuBackdrop) =>
+        {
+            return container(
+                mouse_area(
+                    container(Space::new(Length::Fill, Length::Fill))
+                ).on_press(Message::CloseContextMenu)
+            ).width(Length::Fill).height(Length::Fill).into();
+        }
         Some(WindowInfo::ContextMenu)      => return context_menu_view(&app.context_menu_data, &app.ron_config),
         Some(WindowInfo::Calendar)         => return calendar_view(app),
         Some(WindowInfo::VolumeOutputMixer) => return volume_mixer_view(app, MixerKind::Output),

--- a/src/view.rs
+++ b/src/view.rs
@@ -35,29 +35,50 @@ pub enum Axis
 // ============ FUNCTIONS ============
 pub fn view(app: &AppData, id: iced::window::Id) -> Element<'_, Message>
 {
-    match id_info(app, id) 
+    match id_info(app, id)
     {
         Some(WindowInfo::ContextMenuBackdrop) =>
         {
             return container(
                 mouse_area(
-                    container(Space::new(Length::Fill, Length::Fill))
-                ).on_press(Message::CloseContextMenu)
-            ).width(Length::Fill).height(Length::Fill).into();
+                    container(
+                        Space::new()
+                            .width(Length::Fill)
+                            .height(Length::Fill)
+                    )
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                )
+                .on_press(Message::CloseContextMenu)
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into();
         }
-        Some(WindowInfo::ContextMenu)      => return context_menu_view(&app.context_menu_data, &app.ron_config),
-        Some(WindowInfo::Calendar)         => return calendar_view(app),
-        Some(WindowInfo::VolumeOutputMixer) => return volume_mixer_view(app, MixerKind::Output),
-        Some(WindowInfo::VolumeInputMixer)  => return volume_mixer_view(app, MixerKind::Input),
-        Some(WindowInfo::Warning) if app.config_parsed_failed => { return warning_view(&app.warning_err); },
-        _=> {}
+
+        Some(WindowInfo::ContextMenu) =>
+            return context_menu_view(&app.context_menu_data, &app.ron_config),
+
+        Some(WindowInfo::Calendar) =>
+            return calendar_view(app),
+
+        Some(WindowInfo::VolumeOutputMixer) =>
+            return volume_mixer_view(app, MixerKind::Output),
+
+        Some(WindowInfo::VolumeInputMixer) =>
+            return volume_mixer_view(app, MixerKind::Input),
+
+        Some(WindowInfo::Warning) if app.config_parsed_failed =>
+        {
+            return warning_view(&app.warning_err);
+        }
+
+        _ => {}
     };
 
     MAIN_ID.get_or_init(|| id);
     main_bar_view(app)
 }
-
-
 
 fn main_bar_view(app: &AppData) -> Element<'_, Message>
 {

--- a/src/windows/calendar.rs
+++ b/src/windows/calendar.rs
@@ -1,7 +1,7 @@
 // ============ IMPORTS ============
 use chrono::{Datelike, Local, NaiveDate};
 use iced::{Alignment, Element, Length, Task, Theme, border::Radius, widget::{button, column, container, row, text, Space}};
-use iced_layershell::reexport::{Anchor, Layer, NewLayerShellSettings};
+use iced_layershell::reexport::{Anchor, Layer, NewLayerShellSettings, KeyboardInteractivity};
 use serde::{Deserialize, Serialize};
 
 
@@ -408,22 +408,40 @@ pub fn create_calendar_window(app: &mut AppData) -> Task<Message>
 
     let (mx, my) = app.modules_data.calendar_data.mouse_pos;
     let (pos_x, pos_y) = smart_popup_position(mx, my, app.monitor_size.0 as i32, app.monitor_size.1 as i32, w as i32, h as i32);
+    // backdrop
+    let backdrop_id = iced::window::Id::unique();
+    app.ids.insert(backdrop_id, WindowInfo::ContextMenuBackdrop);
+
+    // calendar window
     let id = iced::window::Id::unique();
     app.ids.insert(id, WindowInfo::Calendar);
-    Task::done(Message::NewLayerShell
+
+    let backdrop_settings = NewLayerShellSettings
     {
-        settings: NewLayerShellSettings
-        {
-            layer:                   Layer::Overlay,
-            size:                    Some((w, h)),
-            exclusive_zone:          Some(0),
-            keyboard_interactivity:  iced_layershell::reexport::KeyboardInteractivity::Exclusive,
-            anchor,
-            margin:                  Some((pos_y, 0, 0, pos_x)),
-            ..Default::default()
-        },
-        id
-    })
+        layer: Layer::Overlay,
+        size: Some((app.monitor_size.0 as u32, app.monitor_size.1 as u32)),
+        exclusive_zone: Some(0),
+        keyboard_interactivity: KeyboardInteractivity::None,
+        anchor: Anchor::Top | Anchor::Left,
+        margin: Some((0, 0, 0, 0)),
+        ..Default::default()
+    };
+
+    let cal_settings = NewLayerShellSettings
+    {
+        layer:                   Layer::Overlay,
+        size:                    Some((w, h)),
+        exclusive_zone:          Some(0),
+        keyboard_interactivity:  KeyboardInteractivity::Exclusive,
+        anchor,
+        margin:                  Some((pos_y, 0, 0, pos_x)),
+        ..Default::default()
+    };
+
+    Task::batch([
+        Task::done(Message::NewLayerShell { settings: backdrop_settings, id: backdrop_id }),
+        Task::done(Message::NewLayerShell { settings: cal_settings, id })
+    ])
 }
 
 

--- a/src/windows/calendar.rs
+++ b/src/windows/calendar.rs
@@ -416,16 +416,16 @@ pub fn create_calendar_window(app: &mut AppData) -> Task<Message>
     let id = iced::window::Id::unique();
     app.ids.insert(id, WindowInfo::Calendar);
 
-    let backdrop_settings = NewLayerShellSettings
-    {
-        layer: Layer::Overlay,
-        size: Some((app.monitor_size.0 as u32, app.monitor_size.1 as u32)),
-        exclusive_zone: Some(0),
-        keyboard_interactivity: KeyboardInteractivity::None,
-        anchor: Anchor::Top | Anchor::Left,
-        margin: Some((0, 0, 0, 0)),
-        ..Default::default()
-    };
+ let backdrop_settings = NewLayerShellSettings
+{
+    layer: Layer::Overlay,
+    size: Some((app.monitor_size.0, app.monitor_size.1)),
+    exclusive_zone: Some(0),
+    keyboard_interactivity: KeyboardInteractivity::None,
+    anchor: Anchor::Top | Anchor::Left,
+    margin: Some((0, 0, 0, 0)),
+    ..Default::default()
+};
 
     let cal_settings = NewLayerShellSettings
     {

--- a/src/windows/context_menu.rs
+++ b/src/windows/context_menu.rs
@@ -126,7 +126,7 @@ pub fn create_context_menu(app: &mut AppData) -> Task<Message>
     let backdrop_settings = NewLayerShellSettings
     {
         layer: Layer::Overlay,
-        size: Some((app.monitor_size.0 as u32, app.monitor_size.1 as u32)),
+        size: Some((app.monitor_size.0, app.monitor_size.1)),
         exclusive_zone: Some(0),
         keyboard_interactivity: KeyboardInteractivity::None,
         anchor: Anchor::Top | Anchor::Left,

--- a/src/windows/context_menu.rs
+++ b/src/windows/context_menu.rs
@@ -1,6 +1,6 @@
 // ============ IMPORTS ============
 use iced::{Alignment, Element, Font, Length, Task, Theme, border::Radius, widget::{button, column, container, row, text}};
-use iced_layershell::reexport::{Anchor, Layer, NewLayerShellSettings};
+use iced_layershell::reexport::{Anchor, Layer, NewLayerShellSettings, KeyboardInteractivity};
 use serde::{Serialize, Deserialize};
 
 
@@ -115,22 +115,40 @@ pub fn create_context_menu(app: &mut AppData) -> Task<Message>
         smart_popup_position(app.context_menu_data.mouse_position.0, app.context_menu_data.mouse_position.1, app.monitor_size.0 as i32, app.monitor_size.1 as i32, context_menu_size.0 as i32, context_menu_size.1 as i32)
     };
 
+    // create a full-screen transparent backdrop to capture outside clicks
+    let backdrop_id = iced::window::Id::unique();
+    app.ids.insert(backdrop_id, WindowInfo::ContextMenuBackdrop);
+
+    // create the actual context menu window
     let id = iced::window::Id::unique();
     app.ids.insert(id, WindowInfo::ContextMenu);
-    Task::done(Message::NewLayerShell
+
+    let backdrop_settings = NewLayerShellSettings
     {
-        settings: NewLayerShellSettings
-        {
-            layer: Layer::Overlay,
-            size: Some((context_menu_size.0, context_menu_size.1)),
-            exclusive_zone: Some(0),
-            keyboard_interactivity: iced_layershell::reexport::KeyboardInteractivity::Exclusive,
-            anchor: anchor_position,
-            margin: Some((context_menu_pos_y, 0, 0, context_menu_pos_x)),
-            ..Default::default()
-        },
-        id
-    })
+        layer: Layer::Overlay,
+        size: Some((app.monitor_size.0 as u32, app.monitor_size.1 as u32)),
+        exclusive_zone: Some(0),
+        keyboard_interactivity: KeyboardInteractivity::None,
+        anchor: Anchor::Top | Anchor::Left,
+        margin: Some((0, 0, 0, 0)),
+        ..Default::default()
+    };
+
+    let menu_settings = NewLayerShellSettings
+    {
+        layer: Layer::Overlay,
+        size: Some((context_menu_size.0, context_menu_size.1)),
+        exclusive_zone: Some(0),
+        keyboard_interactivity: KeyboardInteractivity::Exclusive,
+        anchor: anchor_position,
+        margin: Some((context_menu_pos_y, 0, 0, context_menu_pos_x)),
+        ..Default::default()
+    };
+
+    Task::batch([
+        Task::done(Message::NewLayerShell { settings: backdrop_settings, id: backdrop_id }),
+        Task::done(Message::NewLayerShell { settings: menu_settings, id })
+    ])
 }
 
 

--- a/src/windows/volume_mixer.rs
+++ b/src/windows/volume_mixer.rs
@@ -994,7 +994,7 @@ pub fn create_output_mixer_window(app: &mut AppData) -> Task<Message>
     let backdrop_settings = NewLayerShellSettings
     {
         layer: Layer::Overlay,
-        size: Some((app.monitor_size.0 as u32, app.monitor_size.1 as u32)),
+        size: Some((app.monitor_size.0, app.monitor_size.1)),
         exclusive_zone: Some(0),
         keyboard_interactivity: KeyboardInteractivity::None,
         anchor: Anchor::Top | Anchor::Left,
@@ -1037,7 +1037,7 @@ pub fn create_input_mixer_window(app: &mut AppData) -> Task<Message>
     let backdrop_settings = NewLayerShellSettings
     {
         layer: Layer::Overlay,
-        size: Some((app.monitor_size.0 as u32, app.monitor_size.1 as u32)),
+        size: Some((app.monitor_size.0, app.monitor_size.1)),
         exclusive_zone: Some(0),
         keyboard_interactivity: KeyboardInteractivity::None,
         anchor: Anchor::Top | Anchor::Left,

--- a/src/windows/volume_mixer.rs
+++ b/src/windows/volume_mixer.rs
@@ -1,7 +1,7 @@
 // ============ IMPORTS ============
 use libpulse_binding::{callbacks::ListResult, mainloop::threaded::Mainloop, volume::{ChannelVolumes, Volume}, context::{Context, FlagSet as ContextFlagSet, subscribe::InterestMaskSet}};
 use iced::{Alignment, Element, Length, Task, Theme, widget::{button, column, container, row, scrollable, slider, text, Space}};
-use iced_layershell::reexport::{Anchor, Layer, NewLayerShellSettings};
+use iced_layershell::reexport::{Anchor, Layer, NewLayerShellSettings, KeyboardInteractivity};
 use std::{pin::Pin, sync::{Arc, Mutex}};
 use serde::{Deserialize, Serialize};
 
@@ -983,22 +983,40 @@ pub fn create_output_mixer_window(app: &mut AppData) -> Task<Message>
     let anchor  = bar_anchor(&app.ron_config.general.bar_position);
     let (mx, my) = app.modules_data.volume_mixer_data.mouse_pos;
     let (px, py) = smart_popup_position(mx, my, app.monitor_size.0 as i32, app.monitor_size.1 as i32, w as i32, h as i32);
+    // backdrop
+    let backdrop_id = iced::window::Id::unique();
+    app.ids.insert(backdrop_id, WindowInfo::ContextMenuBackdrop);
+
+    // mixer window
     let id = iced::window::Id::unique();
     app.ids.insert(id, WindowInfo::VolumeOutputMixer);
-    Task::done(Message::NewLayerShell
+
+    let backdrop_settings = NewLayerShellSettings
     {
-        settings: NewLayerShellSettings
-        {
-            layer:                  Layer::Overlay,
-            size:                   Some((w, h)),
-            exclusive_zone:         Some(0),
-            keyboard_interactivity: iced_layershell::reexport::KeyboardInteractivity::Exclusive,
-            anchor,
-            margin:                 Some((py, 0, 0, px)),
-            ..Default::default()
-        },
-        id
-    })
+        layer: Layer::Overlay,
+        size: Some((app.monitor_size.0 as u32, app.monitor_size.1 as u32)),
+        exclusive_zone: Some(0),
+        keyboard_interactivity: KeyboardInteractivity::None,
+        anchor: Anchor::Top | Anchor::Left,
+        margin: Some((0, 0, 0, 0)),
+        ..Default::default()
+    };
+
+    let mixer_settings = NewLayerShellSettings
+    {
+        layer:                  Layer::Overlay,
+        size:                   Some((w, h)),
+        exclusive_zone:         Some(0),
+        keyboard_interactivity: KeyboardInteractivity::Exclusive,
+        anchor,
+        margin:                 Some((py, 0, 0, px)),
+        ..Default::default()
+    };
+
+    Task::batch([
+        Task::done(Message::NewLayerShell { settings: backdrop_settings, id: backdrop_id }),
+        Task::done(Message::NewLayerShell { settings: mixer_settings, id })
+    ])
 }
 
 pub fn create_input_mixer_window(app: &mut AppData) -> Task<Message>
@@ -1008,22 +1026,40 @@ pub fn create_input_mixer_window(app: &mut AppData) -> Task<Message>
     let anchor  = bar_anchor(&app.ron_config.general.bar_position);
     let (mx, my) = app.modules_data.volume_mixer_data.mouse_pos;
     let (px, py) = smart_popup_position(mx, my, app.monitor_size.0 as i32, app.monitor_size.1 as i32, w as i32, h as i32);
+    // backdrop
+    let backdrop_id = iced::window::Id::unique();
+    app.ids.insert(backdrop_id, WindowInfo::ContextMenuBackdrop);
+
+    // mixer window
     let id = iced::window::Id::unique();
     app.ids.insert(id, WindowInfo::VolumeInputMixer);
-    Task::done(Message::NewLayerShell
+
+    let backdrop_settings = NewLayerShellSettings
     {
-        settings: NewLayerShellSettings
-        {
-            layer:                  Layer::Overlay,
-            size:                   Some((w, h)),
-            exclusive_zone:         Some(0),
-            keyboard_interactivity: iced_layershell::reexport::KeyboardInteractivity::Exclusive,
-            anchor,
-            margin:                 Some((py, 0, 0, px)),
-            ..Default::default()
-        },
-        id
-    })
+        layer: Layer::Overlay,
+        size: Some((app.monitor_size.0 as u32, app.monitor_size.1 as u32)),
+        exclusive_zone: Some(0),
+        keyboard_interactivity: KeyboardInteractivity::None,
+        anchor: Anchor::Top | Anchor::Left,
+        margin: Some((0, 0, 0, 0)),
+        ..Default::default()
+    };
+
+    let mixer_settings = NewLayerShellSettings
+    {
+        layer:                  Layer::Overlay,
+        size:                   Some((w, h)),
+        exclusive_zone:         Some(0),
+        keyboard_interactivity: KeyboardInteractivity::Exclusive,
+        anchor,
+        margin:                 Some((py, 0, 0, px)),
+        ..Default::default()
+    };
+
+    Task::batch([
+        Task::done(Message::NewLayerShell { settings: backdrop_settings, id: backdrop_id }),
+        Task::done(Message::NewLayerShell { settings: mixer_settings, id })
+    ])
 }
 
 


### PR DESCRIPTION
Fix #39: popup windows on Hyprland should close automatically when clicking outside the popup area. Currently the popup stays open even after losing focus.
